### PR TITLE
use transitionend

### DIFF
--- a/js/pageslider-react.js
+++ b/js/pageslider-react.js
@@ -12,7 +12,7 @@ var PageSlider = {
             pages = this.state.pages,
             l = pages.length,
             transitionEndHandler = function() {
-                pageEl.removeEventListener('webkitTransitionEnd', transitionEndHandler);
+                pageEl.removeEventListener('transitionend', transitionEndHandler);
                 pages.shift();
                 this.setState({pages: pages});
             }.bind(this),
@@ -23,7 +23,7 @@ var PageSlider = {
                 } else if (l > 0) {
                     pages[l - 1].props.position = "center transition";
                     this.setState({pages: pages, animating: false});
-                    pageEl.addEventListener('webkitTransitionEnd', transitionEndHandler);
+                    pageEl.addEventListener('transitionend', transitionEndHandler);
                 }
             };
 


### PR DESCRIPTION
This PR fixes the bug in Firefox as mentioned in http://coenraets.org/blog/2014/12/animated-page-transitions-with-react-js/#comment-1327223

This change uses the standard **transitionend** event (https://developer.mozilla.org/en-US/docs/Web/Events/transitionend) in place of the webkit specific event
